### PR TITLE
Removing Expired (Pending more than 3 hour) telebirr transaction from…

### DIFF
--- a/app/Console/Commands/RemovePendingPayment.php
+++ b/app/Console/Commands/RemovePendingPayment.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Payment;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class RemovePendingPayment extends Command
+{
+    protected $signature = 'remove:removeOlderPendingTelebirrPayments';
+
+    protected $description = 'Remove pending Telebirr payments older than 3 hours';
+
+    public function handle()
+    {
+        // Get expired payments
+        $expiredPayments = Payment::where('status', 'pending')
+        ->where('payment_type', 'telebirr')
+        ->where('created_at', '<', now()->subHours(3))
+        ->get();
+
+        $count = 0;
+
+        if ($expiredPayments->isNotEmpty()) {
+            foreach ($expiredPayments as $payment) {
+                $payment->delete();
+                $count++;
+            }
+
+            $message = "Successfully soft deleted $count expired pending Telebirr payments.";
+            $this->info($message);
+            Log::info($message);
+        } else {
+            $message = 'No expired Telebirr payments found.';
+            $this->info($message);
+            Log::info($message);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,6 +29,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('equb:sendnotifications')->dailyAt('00:00');
         $schedule->command('equb:autoDrawLottery')->dailyAt('00:00'); // Run every day at midnight
         $schedule->command('equb:draw-winners')->dailyAt('00:00');
+        $schedule->command('remove:removeOlderPendingTelebirrPayments')->everyThreeHours($minutes = 0);
     }
 
     /**


### PR DESCRIPTION
Removing Telebirr payment transactions that are pending and were created more than 3 hours ago (Telebirr transactions are valid for a maximum of 2 hours).